### PR TITLE
Changed CSS style to quote-button and quote_button instead.

### DIFF
--- a/goodbye-quora-embed-button/goodbye.css
+++ b/goodbye-quora-embed-button/goodbye.css
@@ -1,4 +1,4 @@
 /* <div class="hover_menu quote_hover_menu" style="display: block; top: 218px; left: 500.96875px;" id="__w2_ZWDF4jA_menu"><div class="hover_menu_nub" style="background-image: url(https://www.quora.com/static/images/quote_tooltip_nub.png); background-position: 10px 0px; background-repeat: no-repeat no-repeat;"></div><div class="hover_menu_contents quote_button quote-button" id="__w2_ZWDF4jA_menu_contents"><a class="action_button" style="white-space: nowrap;" href="#" id="__w2_bUMbc1U_quote_button"><strong>Embed Quote</strong></a></div></div> */
-.hover_menu , .quote_hover_menu {
+.quote-button , .quote_button {
 	display: none !important;
 }


### PR DESCRIPTION
The previous version's CSS picked up other parts of Quora's site and blocked them. This fix will only make the "Embed Quote" button disappear.
